### PR TITLE
Remove password parameter not used in sign in method

### DIFF
--- a/components/Form.js
+++ b/components/Form.js
@@ -10,7 +10,7 @@ const Form = () => {
   const authenticate = e => {
     e.preventDefault();
     if (username != '' || password != '') {
-      signIn(username, password);
+      signIn(username);
     } else {
       setMessage('Please enter your username and password');
     }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,7 +19,7 @@ export default class MyApp extends App {
     }
   };
 
-  signIn = (username, password) => {
+  signIn = (username) => {
     localStorage.setItem('coolapp-user', username);
 
     this.setState(


### PR DESCRIPTION
Hello, thanks for the example, it helped me a lot in understanding how to share state between pages. I removed the password parameter from the signIn method, the reason is that it is not used